### PR TITLE
Archipack compatibility

### DIFF
--- a/measureit_arch_baseclass.py
+++ b/measureit_arch_baseclass.py
@@ -12,47 +12,58 @@ from bpy.props import IntProperty, CollectionProperty, FloatVectorProperty, Bool
 def update_flag(self,context):
     self.text_updated = True
 
-def update_active_dim(self,context):
-    dimGen = context.object.DimensionGenerator[0]
-    itemType = self.itemType
-    idx = 0
-    for wrap in dimGen.wrappedDimensions:
-        if itemType == wrap.itemType:
-            if itemType == 'D-ALIGNED':
-                if self == dimGen.alignedDimensions[wrap.itemIndex]:
-                    dimGen.active_dimension_index = idx
-                    return
-            elif itemType == 'D-AXIS':
-                if self == dimGen.axisDimensions[wrap.itemIndex]:
-                    dimGen.active_dimension_index = idx
-                    return
-        idx += 1
-    
-def recalc_dimWrapper_index(self,context):
-    dimGen = context.object.DimensionGenerator[0]
-    wrappedDimensions = dimGen.wrappedDimensions
-    id_aligned = 0
-    id_angle = 0
-    id_axis = 0
-    id_arc = 0
-    id_area = 0
-    for dim in wrappedDimensions:
-        if dim.itemType == 'D-ALIGNED':
-            dim.itemIndex = id_aligned
-            id_aligned += 1
-        elif dim.itemType == 'D-ANGLE':
-            dim.itemIndex = id_angle
-            id_angle += 1
-        elif dim.itemType == 'D-AXIS':
-            dim.itemIndex = id_axis
-            id_axis += 1
-        elif dim.itemType == 'D-ARC':
-            dim.itemIndex = id_arc
-            id_arc += 1
-        elif dim.itemType == 'D-AREA':
-            dim.itemIndex = id_area
-            id_area += 1
 
+def has_dimension_generator(context):
+    return context.object is not None and \
+    hasattr(context.object, "DimensionGenerator") and \
+    len(context.object.DimensionGenerator) > 0
+
+
+def update_active_dim(self,context):
+    if has_dimension_generator(context):
+        dimGen = context.object.DimensionGenerator[0]
+        itemType = self.itemType
+        idx = 0
+        for wrap in dimGen.wrappedDimensions:
+            if itemType == wrap.itemType:
+                if itemType == 'D-ALIGNED':
+                    if self == dimGen.alignedDimensions[wrap.itemIndex]:
+                        dimGen.active_dimension_index = idx
+                        return
+                elif itemType == 'D-AXIS':
+                    if self == dimGen.axisDimensions[wrap.itemIndex]:
+                        dimGen.active_dimension_index = idx
+                        return
+            idx += 1
+
+
+def recalc_dimWrapper_index(self,context):
+    if has_dimension_generator(context):
+        dimGen = context.object.DimensionGenerator[0]
+        wrappedDimensions = dimGen.wrappedDimensions
+        id_aligned = 0
+        id_angle = 0
+        id_axis = 0
+        id_arc = 0
+        id_area = 0
+        for dim in wrappedDimensions:
+            if dim.itemType == 'D-ALIGNED':
+                dim.itemIndex = id_aligned
+                id_aligned += 1
+            elif dim.itemType == 'D-ANGLE':
+                dim.itemIndex = id_angle
+                id_angle += 1
+            elif dim.itemType == 'D-AXIS':
+                dim.itemIndex = id_axis
+                id_axis += 1
+            elif dim.itemType == 'D-ARC':
+                dim.itemIndex = id_arc
+                id_arc += 1
+            elif dim.itemType == 'D-AREA':
+                dim.itemIndex = id_area
+                id_area += 1
+
+                
 class BaseProp:
     inFront: BoolProperty(name='inFront',
                 description= 'Draw this element In front of other objects',

--- a/measureit_arch_geometry.py
+++ b/measureit_arch_geometry.py
@@ -2230,10 +2230,14 @@ def select_normal(myobj, dim, normDistVector, midpoint, dimProps):
             if bestNormal.dot(sumNormal)<0:
                 bestNormal.negate()
 
-    # If Face Normals aren't available;
-    # use the cross product of the View Plane Normal and the dimensions distance vector.
-    if myobj.type != 'MESH' or badNormals:
+    
+    if archipack_datablock(myobj):
+        # Use archipack dimension matrix y vector
+        bestNormal = myobj.matrix_world.col[1].to_3d()
 
+    elif myobj.type != 'MESH' or badNormals:
+        # If Face Normals aren't available;
+        # use the cross product of the View Plane Normal and the dimensions distance vector.
         bestNormal = viewAxis.cross(normDistVector)
         if bestNormal.length == 0:
             bestNormal = centerRay
@@ -3587,51 +3591,21 @@ def get_line_vertex(idx,verts,mat):
     return vert
 
 
-def is_valid(o):
-    """ Invalid object no more return None
-    :param o:
-    :return:
-    """
-    try:
-        o.id_data
-        res = True
-    except:
-        res = False
-        pass
-    return res
-
-
 def archipack_datablock(o):
     """
      Return archipack datablock from object
     """
-    d = None
-    if is_valid(o):
-        if o.data is not None:
-            try:
-                for key in o.data.keys():
-                    if "archipack_" in key:
-                        d = getattr(o.data, key)[0]
-                        break
-            except:
-                pass
-        if d is None:
-            try:
-                for key in o.keys():
-                    if "archipack_" in key:
-                        d = getattr(o, key)[0]
-                        break
-            except:
-                pass
-    return d
+    try:
+        return o.data.archipack_dimension_auto[0]
+    except:
+        pass
+    return None
 
 
-def get_archipack_loc(myobj, idx):
+def get_archipack_loc(context, myobj, idx):
     d = archipack_datablock(myobj)
-    if d is not None and hasattr(d, "dimension_points"):
-        pos = d.dimension_point(myobj, idx)
-        if pos is not None:
-            return myobj.matrix_world.inverted() @ pos
+    if d is not None:
+        return d.location(context, myobj, idx)
     return None
 
 


### PR DESCRIPTION
Fixed some context issues as dimension are updated without actually being selected.

Moved logic into archipack_dimension_auto, so archipack's dimension support measureIt arch out of the box, whatever the measured object.

This way manipulating archipack dimension / adding windows to a wall / manipulating wall does update measureIt Arch in real time, and user may add her own measures to regular archipack objects.


What's the purpose of update_active_dim ?
Looks like it is only in use for measure offset.

Definitely must get the rid of wrapped dimension (at least that weak index logic).