### PR TITLE
Fix Freestyle SVG rendering in Blender 4.5

### DIFF
--- a/measureit_arch_render.py
+++ b/measureit_arch_render.py
@@ -41,7 +41,7 @@ from . import svg_shaders
 from . import vector_utils
 from .measureit_arch_geometry import draw3d_loop, batch_for_shader
 from .measureit_arch_main import draw_main, draw_titleblock, text_update_loop,draw_viewport
-from .measureit_arch_utils import get_resolution, get_view, local_attrs, get_loaded_addons, OpenGL_Settings, Set_Render, load_shader_str, get_projection_matrix, get_view_outpath, Inst_Sort
+from .measureit_arch_utils import freestyle_svg_enabled, get_resolution, get_view, local_attrs, OpenGL_Settings, Set_Render, load_shader_str, get_projection_matrix, get_view_outpath, Inst_Sort
 from .measureit_arch_units import BU_TO_INCHES
 
 
@@ -597,7 +597,7 @@ def render_main_svg(self, context):
 
 
         ## Freestyle Embed
-        freestyle_svg_export = 'render_freestyle_svg' in get_loaded_addons()
+        freestyle_svg_export = freestyle_svg_enabled()
         if view.embed_freestyle_svg and freestyle_svg_export:
             # If "FreeStyle SVG export" addon is loaded, we render the scene to SVG
             # and embed the output in the final SVG.

--- a/measureit_arch_utils.py
+++ b/measureit_arch_utils.py
@@ -4,7 +4,7 @@ import gpu
 import os
 
 from mathutils import Vector, Matrix
-from addon_utils import check, paths
+from addon_utils import check, modules
 from sys import getrecursionlimit, setrecursionlimit
 from datetime import datetime
 
@@ -411,14 +411,16 @@ def get_camera_z_dist(location):
     return dist_along_camera_z
 
 def get_loaded_addons():
-    paths_list = paths()
     addon_list = []
-    for path in paths_list:
-        for mod_name, mod_path in bpy.path.module_names(path):
-            is_enabled, is_loaded = check(mod_name)
-            if is_enabled and is_loaded:
-                addon_list.append(mod_name)
+    for mod in modules():
+        is_enabled, is_loaded = check(mod.__name__)
+        if is_enabled and is_loaded:
+            addon_list.append(mod.__name__)
     return addon_list
+
+def freestyle_svg_enabled():
+    freestyle_svg_module_names = ['render_freestyle_svg', 'bl_ext.blender_org.freestyle_svg_exporter']
+    return any(freestyle_svg_name in get_loaded_addons() for freestyle_svg_name in freestyle_svg_module_names)
 
 def get_rv3d():
     spaces = bpy.context.area.spaces

--- a/measureit_arch_views.py
+++ b/measureit_arch_views.py
@@ -25,7 +25,7 @@ from .measureit_arch_render import render_main, render_main_svg, get_view_outpat
 from .measureit_arch_baseclass import TextField, draw_textfield_settings
 from .measureit_arch_geometry import draw3d_loop
 from .measureit_arch_viewports import Viewport
-from . measureit_arch_utils import get_loaded_addons, get_resolution, get_view, _imp_scales_dict, _metric_scales_dict,OpenGL_Settings, Set_Render
+from . measureit_arch_utils import freestyle_svg_enabled, get_resolution, get_view, _imp_scales_dict, _metric_scales_dict,OpenGL_Settings, Set_Render
 from .measureit_arch_units import BU_TO_INCHES
 
 
@@ -1134,7 +1134,7 @@ class SCENE_PT_Views(Panel):
                 col.prop(view, 'skip_hatches')
 
                 col = box.column(align=True)
-                freestyle_svg_export = 'render_freestyle_svg' in get_loaded_addons()
+                freestyle_svg_export = freestyle_svg_enabled()
                 col.active = freestyle_svg_export
                 col.prop(view, "embed_freestyle_svg", text="Embed FreeStyle SVG")
 


### PR DESCRIPTION
Freestyle SVG rendering did not work for me with Blender 4.5 on macOS Sequoia (15.5). The current version of MeasureIt_ARCH could not find the Freestyle SVG Exporter add-on although it was enabled.

The issue seems to be the that the current function for listing enabled modules does not list all enabled modules and searches for a specific name of the Freestyle SVG module which seems to have changed.

This PR uses `addon_utils.modules()` instead of `addon_utils.paths()` to find modules, adds a helper function to find the Freestyle SVG module and an additional name under which this module seems to be available on Blender 4.5 on macOS.