### PR TITLE
Fix use of deprecated `datetime.utcnow()`

### DIFF
--- a/measureit_arch_lines.py
+++ b/measureit_arch_lines.py
@@ -293,7 +293,7 @@ class AddLineButton(Operator):
                 lGroup = lineGen.line_groups.add()
 
                 # Set values
-                lGroup.creation_time = str(int(datetime.utcnow().timestamp() * 100)) 
+                lGroup.creation_time = str(int(datetime.now().timestamp() * 100))
                 lGroup.itemType = 'line_groups'
                 lGroup.style = sceneProps.default_line_style
                 if sceneProps.default_line_style != '':
@@ -352,7 +352,7 @@ class AddDynamicLineButton(Operator):
                 lGroup = lineGen.line_groups.add()
 
                 # Set values
-                lGroup.creation_time = str(int(datetime.utcnow().timestamp() * 100))
+                lGroup.creation_time = str(int(datetime.now().timestamp() * 100))
                 lGroup.itemType = 'line_groups'
                 lGroup.style = sceneProps.default_line_style
                 if sceneProps.default_line_style != '':
@@ -697,7 +697,7 @@ class AddLineByProperty(Operator):
                         lGroup = lineGen.line_groups.add()
 
                         # Set values
-                        lGroup.creation_time = str(int(datetime.utcnow().timestamp() * 100))
+                        lGroup.creation_time = str(int(datetime.now().timestamp() * 100))
                         lGroup.itemType = 'line_groups'
                         lGroup.style = sceneProps.default_line_style
                         if sceneProps.default_line_style != '':


### PR DESCRIPTION
To fix warnings below in Python 3.13 (Blender 5.1+):
```
<python-input-1>:1: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```

Note that `datetime.now().timestamp()` doesn't match exactly `datetime.utcnow().timestamp()` - `utcnow` was returning utc time, but without timezone info, so `.timestamp()` would interpret it as local time. E.g. on GMT+11 it end up creating timestamp actually 11 hours earlier than the current time. 
Anyways, it shouldn't affect the work of the addon, since timestamp is used just for identification (though it seems is never really used anywhere in the code, maybe it was just a planned feature).

@kevancress can you please take a look?