### PR TITLE
Fix mirrored text orientation in renders

### DIFF
--- a/measureit_arch_geometry.py
+++ b/measureit_arch_geometry.py
@@ -3277,12 +3277,13 @@ def draw_text_3D(context, textobj, textprops, myobj):
     j = Vector((0, 1, 0))
     k = Vector((0, 0, 1))
 
-    # Get View rotation
+    # Get view rotation in world space.  The render path uses the camera
+    # matrix, while viewport drawing uses the inverse region view matrix.
     debug_camera = False
     if sceneProps.is_render_draw or debug_camera:
-        view_mat = context.scene.camera.matrix_world
+        view_mat = context.scene.camera.matrix_world.to_3x3()
     else:
-        view_mat = context.area.spaces[0].region_3d.view_matrix
+        view_mat = context.area.spaces[0].region_3d.view_matrix.inverted().to_3x3()
 
     # Define Flip Matrix's
     flipMatrixX = Matrix([
@@ -3312,9 +3313,9 @@ def draw_text_3D(context, textobj, textprops, myobj):
     viewAxisY = j.copy()
     viewAxisZ = k.copy()
 
-    viewAxisX = viewAxisX @ view_mat 
-    viewAxisY = viewAxisY @ view_mat 
-    viewAxisZ = viewAxisZ @ view_mat 
+    viewAxisX = (view_mat @ viewAxisX).normalized()
+    viewAxisY = (view_mat @ viewAxisY).normalized()
+    viewAxisZ = (view_mat @ viewAxisZ).normalized()
 
 
     # Skew Rotation slightly to avoid errors that occur


### PR DESCRIPTION
This PR fixes some dimension and annotation text rendering mirrored/flipped in MeasureIt_ARCH image renders.

I tested the latest `development` branch in Blender 4.2 and 5.1.2 on Windows 10, and some text that looked correct in the viewport would render flipped/mirrored.

This change extracts a 3x3 view basis in world space before comparing axes:

- For camera/render drawing, it uses `context.scene.camera.matrix_world.to_3x3()`.
- For viewport drawing, it uses `region_3d.view_matrix.inverted().to_3x3()`.
- View axes are transformed with `matrix @ vector` and normalized before the dot-product checks.

The existing UV flip logic is kept intact; this just makes the view/card axis comparison consistent between viewport and render paths.

Tested with dimension and annotation text in Blender 4.2 and 5.1.2. 

4.2 Before:
<img width="1920" height="1008" alt="4 2_before" src="https://github.com/user-attachments/assets/b6fba554-87ab-40eb-a472-212fdc794beb" />

4.2 After:
<img width="1920" height="1008" alt="4 2_after" src="https://github.com/user-attachments/assets/69a686de-772b-4709-a15d-a787266312d9" />

5.1.2 Before:
<img width="1920" height="1006" alt="5 1 2_before" src="https://github.com/user-attachments/assets/dd16ce94-5c38-4170-aeea-dd1a2477aeee" />

5.1.2 After:
<img width="1920" height="1006" alt="5 1 2_after" src="https://github.com/user-attachments/assets/2d3975d9-1333-4d5e-917a-f1d96f41ebc7" />